### PR TITLE
Handle search query without a space between dept and course #

### DIFF
--- a/search.php
+++ b/search.php
@@ -10,6 +10,7 @@ if (empty($_GET['query'])) {
 }
 $queryString = trim($_GET['query']);
 $queryString = str_replace($blacklist, "", $queryString);
+$queryString = preg_replace('/^([A-Za-z]*)(\d*)$/', '$1 $2', $queryString);
 $ch = curl_init('http://web-misc1.gatech.edu:9200/class,prof/_search');
 $qry = '{
           "query" : { 


### PR DESCRIPTION
Searching for "cs1331" should return the same results as "cs 1331". This preg_replace adds the space if it matches the former format. 

Test of the regex:

``` php
 $queries = array(
     'c',
     'cs',
     'cs1',
     'cs123',
     'cs 123',
     'csasfsafas',
     'math',
     'loss',
     'loss michael',
 );

 $regex = '/^([A-Za-z]*)(\d*)$/';
 $replacement = '$1 $2';

 foreach ($queries as $query) {
     echo $query . ' -> ' . preg_replace($regex, $replacement, $query) . "\n";
 }
```

Output:

```
$ php test-fuzzy-search.php 
c -> c 
cs -> cs 
cs1 -> cs 1
cs123 -> cs 123
cs 123 -> cs 123
csasfsafas -> csasfsafas 
math -> math 
loss -> loss 
loss michael -> loss michael
```
